### PR TITLE
Adding personId property

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ All properties are optional. Properties not passed in will not be displayed.
 * `familyName` - Family name of the person.
 * `sex` - Sex of the person (lowercase or uppercase). Defaults to `unknown`.
 * `lifespan` - Lifespan of the person.
-* `id` - Id of the person.
+* `id` - Person Id of the person
+* `personId` - Alternate property for displaying the person id.
 * `nameSystem` -  [eurotypic](http://bdespain.org/S&L/angs/glos/ngs-euro.htm) or [sinotypic](http://bdespain.org/S&L/angs/glos/ngs-sino.htm). Used in `orientation=portrait` to determine how a name should be displayed.
 * `portraitUrl` - URL of the image to display as the persons portrait.
 

--- a/fs-person.html
+++ b/fs-person.html
@@ -529,8 +529,8 @@ fs-person[relation="spouse2"] .fs-person__sex:before {
        }
 
        // id
-       if (this.person.id && !noIdAttr) {
-         idEl.textContent = this.person.id;
+       if ((this.person.id || this.person.personId) && !noIdAttr) {
+         idEl.textContent = this.person.personId || this.person.id;
        }
        else {
          idEl.remove();

--- a/src/fs-person.html
+++ b/src/fs-person.html
@@ -529,8 +529,8 @@ fs-person[relation="spouse2"] .fs-person__sex:before {
        }
 
        // id
-       if (this.person.id && !noIdAttr) {
-         idEl.textContent = this.person.id;
+       if ((this.person.id || this.person.personId) && !noIdAttr) {
+         idEl.textContent = this.person.personId || this.person.id;
        }
        else {
          idEl.remove();


### PR DESCRIPTION
Some FamilySearch APIs return the person ID in a property named `personId` and use `id` for a different type of value. This makes it so `personId` is an acceptable property and takes priority over `id`.