### PR TITLE
Adding asset manifest for rootNode() polyfill.

### DIFF
--- a/asset.manifest.json
+++ b/asset.manifest.json
@@ -1,0 +1,5 @@
+{
+  "bowerFiles": [
+    "components/fs-dialog/get-root-node-polyfill.js",
+  ]
+}

--- a/asset.manifest.json
+++ b/asset.manifest.json
@@ -1,5 +1,5 @@
 {
   "bowerFiles": [
-    "components/fs-dialog/get-root-node-polyfill.js",
+    "components/fs-person/get-root-node-polyfill.js",
   ]
 }


### PR DESCRIPTION
Otherwise, the polyfill will get a 403 or 404 on an app.