### PR TITLE
Remove version from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "fs-person",
   "description": "Standard display of a persons sex, name, lifespan, and id for FamilySearch.",
-  "version": "3.1.2",
   "main": "fs-person.html",
   "author": {
     "name": "FamilySearch",


### PR DESCRIPTION
It is better to only have the version tracked in package.json. This prevents possible errors in auto-releases via fs-write because if the bower.json and package.json are ever different, a release is never made, and the component is not updated in the component catalog.