### PR TITLE
bugfix: rerender on attribute changes; feature: add slot for pid wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ You can pass a named slot as a child of `<fs-person>` and it will be used to wra
 </fs-person>
 ```
 
+You can pass a named slot as a child of `<fs-person>` and it will be used to wrap the persons id. This is useful if you need to make the persons id a link or a button.
+
+```html
+<fs-person person="[[person]]">
+  <a href="#" slot="pid"></a>
+</fs-person>
+```
+
 You can also pass in an extra details element as a child of `<fs-person>` and it will be displayed beneath the person's displayed information. This is helpful if you need to add an extra line of information, such as if you want to include a link to let the user "view [their] relationship" with the person.
 
 ```html

--- a/fs-person.html
+++ b/fs-person.html
@@ -402,7 +402,7 @@ fs-person[relation="spouse2"] .fs-person__sex:before {
   class FSPerson extends HTMLElement {
 
     static get observedAttributes() {
-      return ['person'];
+      return ['orientation', 'icon-size', 'portrait', 'no-sex', 'no-lifespan', 'no-id', 'person'];
     }
 
     /*
@@ -431,6 +431,9 @@ fs-person[relation="spouse2"] .fs-person__sex:before {
 
       // accept child name element wrapper
       this._nameSlot = this.querySelector('[slot="name"]');
+
+      // accept pid element wrapper
+      this._pidSlot = this.querySelector('[slot="pid"]');
 
       // accept extra content for the details section
       this._extraDetailsSlot = this.querySelector('[slot="extra-details"]');
@@ -492,9 +495,11 @@ fs-person[relation="spouse2"] .fs-person__sex:before {
          try {
            this.person = JSON.parse(newValue);
          }
-         catch (e) {
-           // ?
+         catch (err) {
+           console.error('There was a problem with the person value in the person attribute:', err)
          }
+       } else {
+         this._render();
        }
      }
 
@@ -621,8 +626,13 @@ fs-person[relation="spouse2"] .fs-person__sex:before {
 
        // id
        if ((this.person.id || this.person.personId) && !noIdAttr) {
-         idEl.textContent = this.person.personId || this.person.id;
-       }
+        if (this._pidSlot) {
+           this._pidSlot.textContent = this.person.personId || this.person.id;
+           idEl.appendChild(this._pidSlot);
+         } else {
+           idEl.textContent = this.person.personId || this.person.id;
+         }
+       } 
        else {
          idEl.remove();
          hideSeparator = true;

--- a/fs-person.html
+++ b/fs-person.html
@@ -345,6 +345,14 @@ fs-person[relation="spouse2"] .fs-person__sex:before {
   *  </fs-person>
   *  ```
   *
+  *  You can pass a named slot as a child of `<fs-person>` and it will be used to wrap the persons id. This is useful if you need to make the persons id a link or a button.
+  *
+  *  ```html
+  *  <fs-person person="[[person]]">
+  *    <a href="#" slot="pid"></a>
+  *  </fs-person>
+  *  ```
+  *
   *  You can also pass in an extra details element as a child of `<fs-person>` and it will be displayed beneath the person's displayed information. This is helpful if you need to add an extra line of information, such as if you want to include a link to let the user "view [their] relationship" with the person.
   *
   *  ```html

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-person",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "Styleguide component for standard display of a persons sex, name, lifespan, and id for FamilySearch.",
   "main": "fs-person.html",
   "directories": {

--- a/src/fs-person.html
+++ b/src/fs-person.html
@@ -402,7 +402,7 @@ fs-person[relation="spouse2"] .fs-person__sex:before {
   class FSPerson extends HTMLElement {
 
     static get observedAttributes() {
-      return ['person'];
+      return ['orientation', 'icon-size', 'portrait', 'no-sex', 'no-lifespan', 'no-id', 'person'];
     }
 
     /*
@@ -431,6 +431,9 @@ fs-person[relation="spouse2"] .fs-person__sex:before {
 
       // accept child name element wrapper
       this._nameSlot = this.querySelector('[slot="name"]');
+
+      // accept pid element wrapper
+      this._pidSlot = this.querySelector('[slot="pid"]');
 
       // accept extra content for the details section
       this._extraDetailsSlot = this.querySelector('[slot="extra-details"]');
@@ -492,9 +495,11 @@ fs-person[relation="spouse2"] .fs-person__sex:before {
          try {
            this.person = JSON.parse(newValue);
          }
-         catch (e) {
-           // ?
+         catch (err) {
+           console.error('There was a problem with the person value in the person attribute:', err)
          }
+       } else {
+         this._render();
        }
      }
 
@@ -621,8 +626,13 @@ fs-person[relation="spouse2"] .fs-person__sex:before {
 
        // id
        if ((this.person.id || this.person.personId) && !noIdAttr) {
-         idEl.textContent = this.person.personId || this.person.id;
-       }
+        if (this._pidSlot) {
+           this._pidSlot.textContent = this.person.personId || this.person.id;
+           idEl.appendChild(this._pidSlot);
+         } else {
+           idEl.textContent = this.person.personId || this.person.id;
+         }
+       } 
        else {
          idEl.remove();
          hideSeparator = true;

--- a/src/fs-person.html
+++ b/src/fs-person.html
@@ -345,6 +345,14 @@ fs-person[relation="spouse2"] .fs-person__sex:before {
   *  </fs-person>
   *  ```
   *
+  *  You can pass a named slot as a child of `<fs-person>` and it will be used to wrap the persons id. This is useful if you need to make the persons id a link or a button.
+  *
+  *  ```html
+  *  <fs-person person="[[person]]">
+  *    <a href="#" slot="pid"></a>
+  *  </fs-person>
+  *  ```
+  *
   *  You can also pass in an extra details element as a child of `<fs-person>` and it will be displayed beneath the person's displayed information. This is helpful if you need to add an extra line of information, such as if you want to include a link to let the user "view [their] relationship" with the person.
   *
   *  ```html


### PR DESCRIPTION
This PR makes two big changes:
- Bugfix: Re-render on certain attribute changes
  - Tree team has a need to be able to update certain attributes (such as portrait) that don't rerender the dom currently. Because these attributes actually manage dom changes, I've added them to the list of observed attributes and then when they get changed run the render function
- Feature: Add slot for pid wrapper
  - Tree team has the need to add a wrapper around the pid so that we can implement our "copy id" feature. This behaves the same way as the name wrapper slot