### PR TITLE
Adjusted .fs-person__sex position top to 9px

### DIFF
--- a/fs-person.html
+++ b/fs-person.html
@@ -49,7 +49,7 @@
 
     .fs-person__sex {
       position: absolute;
-      top: 7px;
+      top: 9px;
     }
 
     .fs-person__sex[class*=fs-icon-medium] {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-person",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Styleguide component for standard display of a persons sex, name, lifespan, and id for FamilySearch.",
   "main": "fs-person.html",
   "directories": {


### PR DESCRIPTION
[JIRA](https://almtools.ldschurch.org/fhjira/browse/TW-1274?filter=38754)

There are two PRs for this issue. [Here is the other one](https://github.com/fs-webdev/fs-styles/pull/116).

On the person page, when the focused person's name uses diacritics that go above the character, it is clipped since its styling uses `overflow: hidden` to allow `text-overflow: ellipsis` to work.  

The other pull request adjusts the `fs-line-height-large-xx` variable to `2.22rem` from `2.15rem` to allow enough space for diacritics. Since this grows its height by a couple pixels, the positioning of the gender icon next to the person's name also needed to be adjusted. That is what this pull request fixes.

It just changes the existing `top: 7px` on the `.fs-person__sex` class to `9px` to re-align it with the new line-height.