### PR TITLE
bugfix: TW-1598 add more specific selector to fs-person__portriat

### DIFF
--- a/fs-person.html
+++ b/fs-person.html
@@ -49,7 +49,7 @@
 
     .fs-person__sex {
       position: absolute;
-      top: 9px;
+      top: 7px;
     }
 
     .fs-person__sex[class*=fs-icon-medium] {
@@ -133,7 +133,7 @@
       text-overflow: ellipsis;
     }
 
-    .fs-person__portrait {
+    .fs-person__portrait.fs-icon {
       background-color: #f4f4f4;
       background-color: var(--fs-color-grey-background-light, #f4f4f4);
       background-size: 60%;

--- a/fs-person.html
+++ b/fs-person.html
@@ -49,7 +49,7 @@
 
     .fs-person__sex {
       position: absolute;
-      top: 7px;
+      top: 9px;
     }
 
     .fs-person__sex[class*=fs-icon-medium] {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-person",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Styleguide component for standard display of a persons sex, name, lifespan, and id for FamilySearch.",
   "main": "fs-person.html",
   "directories": {

--- a/src/fs-person.html
+++ b/src/fs-person.html
@@ -49,7 +49,7 @@
 
     .fs-person__sex {
       position: absolute;
-      top: 7px;
+      top: 9px;
     }
 
     .fs-person__sex[class*=fs-icon-medium] {

--- a/src/fs-person.html
+++ b/src/fs-person.html
@@ -133,7 +133,7 @@
       text-overflow: ellipsis;
     }
 
-    .fs-person__portrait {
+    .fs-person__portrait.fs-icon {
       background-color: #f4f4f4;
       background-color: var(--fs-color-grey-background-light, #f4f4f4);
       background-size: 60%;


### PR DESCRIPTION
* when firefox uses the shadow dom polyfill, the styleguide fs-icon style tends to be more specific than .fs-person__portrait because it will be .component-name.fs-icon and the fs-person styles do not get modified by the polyfill since this isn't a polymer component. This gives it better specificity and resolve the issues of fs-icon styles in fs-styles overriding our styles in fs-person