### PR TITLE
Hide person details section if no-lifespan and no-pid are set

### DIFF
--- a/fs-person.html
+++ b/fs-person.html
@@ -52,6 +52,14 @@
       top: 9px;
     }
 
+    fs-person[no-lifespan][no-id] .fs-person__details {
+      display: none;
+    }
+
+    fs-person[no-lifespan][no-id][icon-size="small"] .fs-person__sex {
+      top: calc(50% - (0.571rem / 2));
+    }
+
     .fs-person__sex[class*=fs-icon-medium] {
       top: 50%;
       transform: translateY(-50%);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-person",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Styleguide component for standard display of a persons sex, name, lifespan, and id for FamilySearch.",
   "main": "fs-person.html",
   "directories": {

--- a/src/fs-person.html
+++ b/src/fs-person.html
@@ -52,6 +52,14 @@
       top: 9px;
     }
 
+    fs-person[no-lifespan][no-id] .fs-person__details {
+      display: none;
+    }
+
+    fs-person[no-lifespan][no-id][icon-size="small"] .fs-person__sex {
+      top: calc(50% - (0.571rem / 2));
+    }
+
     .fs-person__sex[class*=fs-icon-medium] {
       top: 50%;
       transform: translateY(-50%);


### PR DESCRIPTION
Makes the node the expected height, and allows dot to be positioned more accurately via percentage.

![47382761-3ff6bd80-d6c0-11e8-8987-007f92c03c4c](https://user-images.githubusercontent.com/2700098/47384144-839ef680-d6c3-11e8-9c33-1e99ff38fb29.gif)