### PR TITLE
TK-281836: Checks for `broken` (from /tree-data) portrait URL.

### DIFF
--- a/fs-person.html
+++ b/fs-person.html
@@ -559,7 +559,7 @@
          portraitEl.classList.add('fs-icon-large-' + sex);
 
          // portrait url has content
-         if (this.person.portraitUrl) {
+         if (this.person.portraitUrl && this.person.portraitUrl !== 'broken') { // Handle tree-data "broken" portraitURL person attribute. Don't show a broken image.
            imageEl.setAttribute('src', this.person.portraitUrl);
          }
          else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-person",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "Styleguide component for standard display of a persons sex, name, lifespan, and id for FamilySearch.",
   "main": "fs-person.html",
   "directories": {

--- a/src/fs-person.html
+++ b/src/fs-person.html
@@ -559,7 +559,7 @@
          portraitEl.classList.add('fs-icon-large-' + sex);
 
          // portrait url has content
-         if (this.person.portraitUrl) {
+         if (this.person.portraitUrl && this.person.portraitUrl !== 'broken') { // Handle tree-data "broken" portraitURL person attribute. Don't show a broken image.
            imageEl.setAttribute('src', this.person.portraitUrl);
          }
          else {

--- a/test/fs-person-test.html
+++ b/test/fs-person-test.html
@@ -220,6 +220,15 @@
           expect(imageEl.getAttribute('src')).to.equal(person.portraitUrl);
         });
 
+        it('"portrait" should not show the image when portraitUrl equals "broken"', function() {
+          el.setAttribute('portrait', '');
+
+          person.portraitUrl = 'broken'; // This is a possible return value from /tree-data
+          setPerson();
+
+          expect(imageEl, 'imageEl is not null').to.equal(null);
+        });
+
         it('"portrait" should remove the image if portraitUrl is not passed in', function() {
           el.setAttribute('portrait', '');
           person.portraitUrl = null;

--- a/test/fs-person-test.html
+++ b/test/fs-person-test.html
@@ -220,13 +220,19 @@
           expect(imageEl.getAttribute('src')).to.equal(person.portraitUrl);
         });
 
-        it('"portrait" should not show the image when portraitUrl equals "broken"', function() {
+        it('"portrait" should not show the image when portraitUrl equals exactly "broken"', function() {
           el.setAttribute('portrait', '');
 
           person.portraitUrl = 'broken'; // This is a possible return value from /tree-data
           setPerson();
 
           expect(imageEl, 'imageEl is not null').to.equal(null);
+
+
+          person.portraitUrl = '/broken'; // This is a possible return value from /tree-data
+          setPerson();
+
+          expect(imageEl, 'imageEl is null').to.exist;
         });
 
         it('"portrait" should remove the image if portraitUrl is not passed in', function() {


### PR DESCRIPTION
This change is to prevent broken image icons from showing on persons when /tree-data returns `broken` (https://github.com/fs-eng/tree-data/search?q=BROKEN_URL_PLACEHOLDER&unscoped_q=BROKEN_URL_PLACEHOLDER). We would rather just have the silhouette show.

If there are concerns with having this check here, Treeweb will have to add the check to its components or we will need to find a change for tree-data.