### PR TITLE
Option to have names wrap instead of clip with ellipses

### DIFF
--- a/fs-person.html
+++ b/fs-person.html
@@ -60,7 +60,7 @@
       top: calc(50% - (0.571rem / 2));
     }
 
-    .fs-person__sex[class*=fs-icon-medium] {
+    fs-person:not([wrap-name]) .fs-person__sex[class*=fs-icon-medium] {
       top: 50%;
       transform: translateY(-50%);
     }
@@ -77,6 +77,9 @@
 
     .fs-person__name {
       font-weight: bold;
+    }
+
+    fs-person:not([wrap-name]) .fs-person__name {
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -158,8 +161,6 @@
       position: relative;
       z-index: 1;
     }
-
-
 
 
 
@@ -382,6 +383,7 @@
   *  - `no-sex` - Hide the persons sex.
   *  - `no-lifespan` - Hide the persons lifespan.
   *  - `no-id` - Hide the persons id.
+  *  - `wrap-name` - Enable this attribute to wrap the person's name. Defaults to being clipped with ellipses.
   *  - `relation` - Show two persons as having a relationship by having two `<fs-person>` elements as siblings and adding the `relation` attribute to both. The value of the attribute should be `spouse1` for the first person, and `spouse2` for the second person.
   *
   *  ```html

--- a/src/fs-person.html
+++ b/src/fs-person.html
@@ -60,7 +60,7 @@
       top: calc(50% - (0.571rem / 2));
     }
 
-    .fs-person__sex[class*=fs-icon-medium] {
+    fs-person:not([wrap-name]) .fs-person__sex[class*=fs-icon-medium] {
       top: 50%;
       transform: translateY(-50%);
     }
@@ -77,6 +77,9 @@
 
     .fs-person__name {
       font-weight: bold;
+    }
+
+    fs-person:not([wrap-name]) .fs-person__name {
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -158,8 +161,6 @@
       position: relative;
       z-index: 1;
     }
-
-
 
 
 
@@ -382,6 +383,7 @@
   *  - `no-sex` - Hide the persons sex.
   *  - `no-lifespan` - Hide the persons lifespan.
   *  - `no-id` - Hide the persons id.
+  *  - `wrap-name` - Enable this attribute to wrap the person's name. Defaults to being clipped with ellipses.
   *  - `relation` - Show two persons as having a relationship by having two `<fs-person>` elements as siblings and adding the `relation` attribute to both. The value of the attribute should be `spouse1` for the first person, and `spouse2` for the second person.
   *
   *  ```html


### PR DESCRIPTION
Add a `wrap-name` attribute which just modifies which CSS is applied. Default behavior remains the same. Adding `wrap-name` just removes the wrapping CSS on the name and removes the vertical centering of the sex icon (because we want it lined up with the first line of the name and not the entire vitals container).

Default:

![image](https://user-images.githubusercontent.com/1037458/49763593-5e257680-fc8a-11e8-910a-8f7f0ed0fde9.png)

`wrap-name`:

![image](https://user-images.githubusercontent.com/1037458/49763606-6b426580-fc8a-11e8-8168-807ca0779e06.png)
 