### PR TITLE
Add a new orientation of "inline-column"

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -58,6 +58,8 @@
 <fs-person orientation="portrait" style="width: 300px"></fs-person>
 <h5>orientation=inline</h5>
 <fs-person orientation="inline"></fs-person>
+<h5>orientation=inline-column</h5>
+<fs-person orientation="inline-column"></fs-person>
 
 <h5>icon-size=small</h5>
 <fs-person icon-size="small"></fs-person>

--- a/fs-person.html
+++ b/fs-person.html
@@ -49,7 +49,7 @@
 
     .fs-person__sex {
       position: absolute;
-      top: 9px;
+      top: 6px;
     }
 
     fs-person[no-lifespan][no-id] .fs-person__details {
@@ -173,7 +173,7 @@
       display: none;
     }
 
-    fs-person[orientation="inline"] .fs-person__vitals, {
+    fs-person[orientation="inline"] .fs-person__vitals {
       display: flex;
     }
 
@@ -190,6 +190,7 @@
 
     fs-person[orientation="inline"] .fs-person__details {
       padding-left: 0;
+      padding-top: 2px;
       flex-shrink: 10000; /* [1] */
     }
 
@@ -199,14 +200,19 @@
 
     fs-person[orientation="inline-column"] .fs-person__full-name {
       display: block;
-      padding-top: 3px;
     }
 
     fs-person[orientation="inline-column"] .fs-person__sex ~ .fs-person__name {
       padding-left: 13px;
     }
+    
+    fs-person[orientation="inline-column"] .fs-person__separator {
+      display: none;
+    }
 
-
+    fs-person[orientation="inline-column"] .fs-person__lifespan {
+      display: block;
+    }
 
 
 

--- a/fs-person.html
+++ b/fs-person.html
@@ -168,15 +168,22 @@
     /*
      * 1. make the name shrink at a very low rate compared to the lifespan (magic number)
      */
-    fs-person[orientation="inline"] .fs-person__portrait {
+    fs-person[orientation="inline"] .fs-person__portrait,
+    fs-person[orientation="inline-column"] .fs-person__portrait {
       display: none;
     }
 
-    fs-person[orientation="inline"] .fs-person__vitals {
+    fs-person[orientation="inline"] .fs-person__vitals, {
       display: flex;
     }
 
-    fs-person[orientation="inline"] .fs-person__name {
+    fs-person[orientation="inline-column"] .fs-person__vitals {
+      display: flex;
+      flex-direction: column;
+    }
+
+    fs-person[orientation="inline"] .fs-person__name,
+    fs-person[orientation="inline-column"] .fs-person__name {
       flex-shrink: 1; /* [1] */
       margin-right: 30px;
     }
@@ -184,6 +191,19 @@
     fs-person[orientation="inline"] .fs-person__details {
       padding-left: 0;
       flex-shrink: 10000; /* [1] */
+    }
+
+    fs-person[orientation="inline-column"] .fs-person__details {
+      padding-left: 12px;
+    }
+
+    fs-person[orientation="inline-column"] .fs-person__full-name {
+      display: block;
+      padding-top: 3px;
+    }
+
+    fs-person[orientation="inline-column"] .fs-person__sex ~ .fs-person__name {
+      padding-left: 13px;
     }
 
 
@@ -577,7 +597,7 @@
          var iconSize = DEFAULT_ICON_SIZE
 
          // never allow a medium sex icon if the portrait is showing or when inline
-         if (portraitAttr || orientationAttr === 'inline') {
+         if (portraitAttr || ((orientationAttr || '').indexOf('inline') === 0)) {
            iconSize = 'small';
          }
          else if (VALID_ICON_SIZES.indexOf(iconSizeAttr) !== -1) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-person",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Styleguide component for standard display of a persons sex, name, lifespan, and id for FamilySearch.",
   "main": "fs-person.html",
   "directories": {


### PR DESCRIPTION
Add a new orientation of "inline-column" that is similar to "inline" but has a column/stacked layout. Fix small icon to be centered vertically with the name.

The immediate need is on the search results of the new v8 Tree > Find page:

![image](https://user-images.githubusercontent.com/1156467/50358693-76fa1b80-0517-11e9-9a66-9ab1316dd474.png)

Here's a sample usage:

```<fs-tree-person icon-size="small" person-obj="[[personObj]]"  orientation="inline-column" no-bold-name no-lifespan open-person-card></fs-tree-person>```
