### PR TITLE
TW-2086: Fixed Text Clipping on Person Header in Safari

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "fs-person",
   "description": "Styleguide component for standard display of a persons sex, name, lifespan, and id for FamilySearch.",
+  "version": "4.3.3",
   "main": "fs-person.html",
   "author": {
     "name": "FamilySearch",

--- a/fs-person.html
+++ b/fs-person.html
@@ -103,8 +103,8 @@
     .fs-person__details {
       font-size: 12px;
       font-size: var(--fs-font-size-small, 12px);
-      height: 1.35rem;
-      height: var(--fs-line-height-small, 1.35rem);
+      height: 1.9rem;
+      height: var(--fs-line-height-medium, 1.9rem);
       line-height: 1.35rem; /* [9] */
       line-height: var(--fs-line-height-small, 1.35rem);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-person",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Styleguide component for standard display of a persons sex, name, lifespan, and id for FamilySearch.",
   "main": "fs-person.html",
   "directories": {


### PR DESCRIPTION
Fixed text clipping on person header Safari with CSS, height was adjusted to accommodate font-size & line-height.  Patch version bumped.