### PR TITLE
Support showing most sinotypic names on two lines, with the exception of ja/ko/zh

### DIFF
--- a/fs-person.html
+++ b/fs-person.html
@@ -230,13 +230,18 @@
     }
 
     /* [1] */
+    fs-person[orientation="portrait"] .fs-person__name.fs-person__name--sinotypic {
+      display: flex;
+      flex-direction: column-reverse;
+    }
+
     fs-person[orientation="portrait"] .fs-person__sex,
-    fs-person[orientation="portrait"] .fs-person__name:not(.fs-person__name--sinotypic) .fs-person__full-name {
+    fs-person[orientation="portrait"] .fs-person__name:not(.fs-person__name--single-line) .fs-person__full-name {
       display: none;
     }
 
-    fs-person[orientation="portrait"] .fs-person__name:not(.fs-person__name--sinotypic) .fs-person__given-name,
-    fs-person[orientation="portrait"] .fs-person__name:not(.fs-person__name--sinotypic) .fs-person__family-name {
+    fs-person[orientation="portrait"] .fs-person__name:not(.fs-person__name--single-line) .fs-person__given-name,
+    fs-person[orientation="portrait"] .fs-person__name:not(.fs-person__name--single-line) .fs-person__family-name {
       display: block;
       line-height: 1.5rem;
     }
@@ -632,6 +637,14 @@
        // name system
        if (this.person.nameSystem) {
          nameEl.classList.add('fs-person__name--' + this.person.nameSystem);
+       }
+
+       // Some languages always have their names displayed on a single line even in portrait mode
+       // https://almtools.ldschurch.org/fhconfluence/display/Product/TreeWeb%3A+Design%3A+Name+Form+Language+Support
+       if (this.person.lang) {
+         if (!this.person.lang.includes('Latn') && (['ja', 'ko', 'zh'].includes(this.person.lang.slice(0, 2)) )) {
+          nameEl.classList.add('fs-person__name--single-line');
+         }
        }
 
        // full name

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-person",
-  "version": "4.3.2",
+  "version": "4.4.0",
   "description": "Styleguide component for standard display of a persons sex, name, lifespan, and id for FamilySearch.",
   "main": "fs-person.html",
   "directories": {

--- a/src/fs-person.html
+++ b/src/fs-person.html
@@ -230,13 +230,18 @@
     }
 
     /* [1] */
+    fs-person[orientation="portrait"] .fs-person__name.fs-person__name--sinotypic {
+      display: flex;
+      flex-direction: column-reverse;
+    }
+
     fs-person[orientation="portrait"] .fs-person__sex,
-    fs-person[orientation="portrait"] .fs-person__name:not(.fs-person__name--sinotypic) .fs-person__full-name {
+    fs-person[orientation="portrait"] .fs-person__name:not(.fs-person__name--single-line) .fs-person__full-name {
       display: none;
     }
 
-    fs-person[orientation="portrait"] .fs-person__name:not(.fs-person__name--sinotypic) .fs-person__given-name,
-    fs-person[orientation="portrait"] .fs-person__name:not(.fs-person__name--sinotypic) .fs-person__family-name {
+    fs-person[orientation="portrait"] .fs-person__name:not(.fs-person__name--single-line) .fs-person__given-name,
+    fs-person[orientation="portrait"] .fs-person__name:not(.fs-person__name--single-line) .fs-person__family-name {
       display: block;
       line-height: 1.5rem;
     }
@@ -632,6 +637,14 @@
        // name system
        if (this.person.nameSystem) {
          nameEl.classList.add('fs-person__name--' + this.person.nameSystem);
+       }
+
+       // Some languages always have their names displayed on a single line even in portrait mode
+       // https://almtools.ldschurch.org/fhconfluence/display/Product/TreeWeb%3A+Design%3A+Name+Form+Language+Support
+       if (this.person.lang) {
+         if (!this.person.lang.includes('Latn') && (['ja', 'ko', 'zh'].includes(this.person.lang.slice(0, 2)) )) {
+          nameEl.classList.add('fs-person__name--single-line');
+         }
        }
 
        // full name


### PR DESCRIPTION
Tree supports many languages for names and the rules for displaying names in portrait mode for most sinotypic languages would put the last name and first name on separate lines. The only sinotypic languages that are an exception to this rule happen to be the only sinotypic languages that we support across the site (zh, ko, ja).

See this confluence page for full details on name form support in the tree:
https://almtools.ldschurch.org/fhconfluence/display/Product/TreeWeb%3A+Design%3A+Name+Form+Language+Support

# Changes:
- By default, display sinotypic names on separate lines in reverse order
- Add single-line class for zh, ko, ja, except for their latin/roman variant (*-Latn)