### PR TITLE
SITE-2440: Person header text clipping fix.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "fs-person",
+  "version": "4.4.1",
   "description": "Styleguide component for standard display of a persons sex, name, lifespan, and id for FamilySearch.",
   "main": "fs-person.html",
   "author": {

--- a/fs-person.html
+++ b/fs-person.html
@@ -103,8 +103,6 @@
     .fs-person__details {
       font-size: 12px;
       font-size: var(--fs-font-size-small, 12px);
-      height: 1.35rem;
-      height: var(--fs-line-height-small, 1.35rem);
       line-height: 1.35rem; /* [9] */
       line-height: var(--fs-line-height-small, 1.35rem);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-person",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Styleguide component for standard display of a persons sex, name, lifespan, and id for FamilySearch.",
   "main": "fs-person.html",
   "directories": {

--- a/src/fs-person.html
+++ b/src/fs-person.html
@@ -103,8 +103,6 @@
     .fs-person__details {
       font-size: 12px;
       font-size: var(--fs-font-size-small, 12px);
-      height: 1.35rem;
-      height: var(--fs-line-height-small, 1.35rem);
       line-height: 1.35rem; /* [9] */
       line-height: var(--fs-line-height-small, 1.35rem);
     }


### PR DESCRIPTION
Descenders were being clipped most notably in Safari on the person page (on the PID and lifespan).  The .fs-person__details CSS class already adjusts the line-height and font-size of the container to properly fit the containing text - setting a height caused clipping of descenders - removing the height fixes it.  See https://almtools.ldschurch.org/fhjira/browse/SITE-2440.